### PR TITLE
Show new messages

### DIFF
--- a/app/controllers/matches/admin.js
+++ b/app/controllers/matches/admin.js
@@ -27,21 +27,17 @@ import MatchesBaseController from './base';
       },
 
       saveMessage(){
-        // Get the parent match
-        var model = this.get('model');
-        var self = this;
-        var message_text=this.get("message_text");
-        var newMessage = this.store.createRecord('message', {
-          message: model.get('minutes') + ' min. - ' + message_text,
-          timestamp: new Date().getTime()
-        });
+        var model = this.get('model'),
+            newMessage = this.store.createRecord('message', {
+              message: model.get('minutes') + ' min. - ' + this.get('message_text'),
+              timestamp: new Date().getTime()
+            });
 
-        model.get('messages.[]').pushObject(newMessage);
-        // Save the message, then save the match
-        newMessage.save().then(function() {
-          self.set('message_text', '');
-          return model.save();
-        });
+        var messages = model.get('messages');
+
+        this.set('message_text', '');
+        messages.addObject(newMessage);
+        model.save();
       },
 
       clearMessages() {

--- a/app/models/match.js
+++ b/app/models/match.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 import Ember from 'ember';
 
 export default DS.Model.extend({
-  messages: DS.hasMany('message', {async: true}),
+  messages: DS.hasMany('message', { async: false, embedded: true }),
   team1Name: DS.attr('string'),
   team2Name: DS.attr('string'),
   team1Score: DS.attr('number',{ defaultValue: 0 }),

--- a/app/models/message.js
+++ b/app/models/message.js
@@ -1,7 +1,6 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  match: DS.belongsTo('match', {async: true}),
   message: DS.attr('string'),
-  timestamp: DS.attr('number')  
+  timestamp: DS.attr('number')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -12,9 +12,7 @@ Router.map(function() {
     this.route('show', {
       path: ':match_id'
     }, function () {
-      this.route('messages',{resetNamespace: true}, function () {
-
-      });
+      this.route('messages',{ resetNamespace: true }, function () {});
     });
 
     this.route('admin', {

--- a/app/routes/matches/show.js
+++ b/app/routes/matches/show.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-});

--- a/app/routes/messages/index.js
+++ b/app/routes/messages/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model(){
+  model() {
     return this.modelFor('matches.show').get('messages');
   }
 });

--- a/bower.json
+++ b/bower.json
@@ -1,21 +1,21 @@
 {
   "name": "ember-league",
   "dependencies": {
-    "ember": "1.13.3",
+    "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.5",
+    "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.1",
+    "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
     "firebase": "^2.1.0",
     "bootstrap": "~3.3.5",
     "jquery-knob": "~1.2.11",
     "fontawesome": "4.3.0",
-    "animate.css": "3.2.6"
+    "animate.css": "3.2.6",
+    "jquery": "^1.11.3",
+    "loader.js": "ember-cli/loader.js#3.2.1",
+    "qunit": "~1.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember test"
   },
   "repository": "",
@@ -19,26 +19,27 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.1",
-    "ember-cli-app-version": "0.4.0",
-    "ember-cli-babel": "^5.0.0",
+    "broccoli-asset-rev": "^2.1.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "0.5.0",
+    "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-dependency-checker": "^1.0.1",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.15",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.0",
     "ember-cli-release": "0.2.3",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-data": "1.13.5",
+    "ember-cli-sri": "^1.0.3",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "1.13.8",
     "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.2",
     "emberfire": "1.5.0",
     "liquid-fire": "^0.21.2",
     "torii": "0.5.1",
     "ui-icon": "0.5.1",
-    "ui-knob": "0.1.1"
+    "ui-knob": "0.1.1",
+    "ember-export-application-global": "^1.0.3"
   }
 }


### PR DESCRIPTION
@xymbol @lvl4ul2i Hice un par de cambios en la aplicación para que se actualicen los mensajes cuando se agregan a Firebase.

Lo primero que note es que, parado en la vista de mensajes de un partido, mirando la pestaña Network de Chrome, el web socket que usa Firebase para sincronizar los datos, no recibía notificaciones de los nuevos mensajes pero sí había notificaciones cuando se actualizaba el `match`. De esto sospecho dos cosas:
1. Utilizando `this.modelFor("match.show").get("messages")` no hace que `emberfire` "escuche" por cambios en el arreglo de mensajes
2. Si en vez de tratar las relaciones como asíncronas, las trato como `embedded`, entonces cuando cambie un mensaje, necesariamente cambia el `match`.

La primera sospecha no la probé, estaría bueno cambiar un poco el código para ver si accediendo a los mensajes con un `this.store.findQuery` o algo así, se logra que emberfire "escuche" por los cambios en los mensajes.

La segunda es la que implementé en este PR, lo que hace es meter los mensajes como recursos embebidos en los partidos, por lo que ahora sí se acutaliza bien.

¿Opiniones o preguntas? Estaría bueno mas adelante probar lo otro para ver si funciona también.

En la documentación de `emberfire` hay un apartado sobre recursos `Embedded` https://www.firebase.com/docs/web/libraries/ember/guide.html
